### PR TITLE
Add cookie support to Request and Response objects

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -35,6 +35,16 @@ class Request implements RequestInterface, Form\RequestInterface
         return $_SESSION[$key] ?? $default;
     }
 
+    /**
+     * @param string $key
+     * @param string|null $default
+     * @return mixed
+     */
+    public function getCookie(string $key, string $default = null)
+    {
+        return $_COOKIE[$key] ?? $default;
+    }
+
     public function getHeader(string $key): string
     {
         $headers = $this->getHeaders();

--- a/src/RequestInterface.php
+++ b/src/RequestInterface.php
@@ -17,4 +17,11 @@ interface RequestInterface
      * @return mixed
      */
     public function getSessionParam(string $key, ?string $default = null);
+
+    /**
+     * @param string $key
+     * @param string|null $default
+     * @return mixed
+     */
+    public function getCookie(string $key, ?string $default = null);
 }

--- a/src/ResponseWriterInterface.php
+++ b/src/ResponseWriterInterface.php
@@ -23,4 +23,11 @@ interface ResponseWriterInterface extends WriterInterface
      * @return void
      */
     public function setSessionParam(string $key, string $value);
+
+    /**
+     * @param string $key
+     * @param string $value
+     * @param array $options
+     */
+    public function setCookie(string $key, string $value, array $options = []);
 }


### PR DESCRIPTION
We want to be able to set and retrieve cookies during the request lifecycle. This changeset adds simple support for doing so.